### PR TITLE
fix block argument rendering in call expressions

### DIFF
--- a/src/gleamgen/expression.gleam
+++ b/src/gleamgen/expression.gleam
@@ -1212,11 +1212,42 @@ fn render_expressions(
   #(rendered |> list.reverse(), details)
 }
 
+/// Render a call expression while handling block arguments context-sensitively.
+///
+/// Multi-statement blocks must stay wrapped in `{ ... }` when passed as call
+/// arguments, while single direct-return blocks can be unwrapped.
 fn render_call(func, args, context) {
-  let #(rendered_args, details) = render_expressions(args, context)
+  // We build `rendered_args` in reverse via prepending for efficiency:
+  // args [a, b] -> acc [b_doc, a_doc], then reverse before pretty_list.
+  let #(rendered_args, details) =
+    list.fold(args, #([], render.empty_details), fn(acc, arg) {
+      let rendered = render_call_argument(arg, context)
+      #([rendered.doc, ..acc.0], render.merge_details(rendered.details, acc.1))
+    })
   let caller = render(func, context)
-  doc.concat([caller.doc, render.pretty_list(rendered_args)])
+  doc.concat([caller.doc, render.pretty_list(list.reverse(rendered_args))])
   |> render.Render(details: render.merge_details(details, caller.details))
+}
+
+/// Render one call argument and preserve semantics for block arguments.
+///
+/// - `{ let x = ...; ... }` stays a block argument
+/// - `{ expr }` is simplified to `expr`
+fn render_call_argument(
+  arg: Expression(types.Dynamic),
+  context: render.Context,
+) {
+  case arg.internal {
+    // A block that only contains a returned expression can be passed directly.
+    Block([ExpressionStatement(expr)]) -> render(expr, context)
+    // Any larger block needs explicit braces when used as a call argument.
+    Block(_) ->
+      render(
+        arg,
+        render.Context(..context, include_brackets_current_level: True),
+      )
+    _ -> render(arg, context)
+  }
 }
 
 fn render_constructor(func, context) {

--- a/test/gleamgen_test.gleam
+++ b/test/gleamgen_test.gleam
@@ -1315,6 +1315,43 @@ pub fn do_result() -> Result(Int, String) {
   assert result == expected
 }
 
+/// Regression test for rendering block arguments in call expressions.
+///
+/// Ensures calls like `result.try(...)` keep braces for block arguments with
+/// `let` statements, while still unwrapping single direct-return blocks.
+pub fn call_with_block_argument_test() {
+  let with_let =
+    expression.call_dynamic(expression.raw("result.try"), [
+      expression.ok(expression.int(3)) |> expression.to_dynamic(),
+      block.with_let_declaration("next", expression.int(4), fn(next) {
+        expression.ok(next)
+      })
+      |> expression.to_dynamic(),
+    ])
+    |> expression.render(render.default_context())
+    |> render.to_string()
+
+  let expected_with_let =
+    "result.try(Ok(3), {
+    let next = 4
+    Ok(next)
+  })"
+
+  assert with_let == expected_with_let
+
+  let direct_return =
+    expression.call_dynamic(expression.raw("result.try"), [
+      expression.ok(expression.int(3)) |> expression.to_dynamic(),
+      block.new_dynamic([statement.expression(expression.ok(expression.int(4)))]),
+    ])
+    |> expression.render(render.default_context())
+    |> render.to_string()
+
+  let expected_direct_return = "result.try(Ok(3), Ok(4))"
+
+  assert direct_return == expected_direct_return
+}
+
 pub fn result_test() {
   let mod = {
     use result_module <- module.with_import(import_.new(["gleam", "result"]))


### PR DESCRIPTION
**Context**
I'm working on a DB access layer, for this I'm using gleamgen.
I found the following bug, and used a test-driven flow to fix the issue with cusor's Composer-2 model.
I have done a self-review and am sufficiently confident I did not introduce a bitcoin miner into the library.
All tests pass

`result.try(...)` with a callback/block argument can contain either:
- multiple statements (e.g. `let ...` then return), or
- a single direct return expression.
**Actual (before)**
- Block arguments were rendered inconsistently, and single-expression block arguments stayed wrapped in braces.
1
**Expected**
- Keep `{ ... }` for multi-statement block arguments.
- Omit braces when the block contains only one direct return expression.
**Included**
- Renderer update for call arguments.
- Regression tests for both forms around `result.try(...)`.
✅ `gleam test` passes.
