### PR TITLE
Fix/pattern list rendering and helpers

### DIFF
--- a/src/gleamgen/expression.gleam
+++ b/src/gleamgen/expression.gleam
@@ -1224,15 +1224,9 @@ fn render_call(func, args, context) {
   // (e.g. as a function body).
   let arg_context =
     render.Context(..context, include_brackets_current_level: True)
-  // We build `rendered_args` in reverse via prepending for efficiency:
-  // args [a, b] -> acc [b_doc, a_doc], then reverse before pretty_list.
-  let #(rendered_args, details) =
-    list.fold(args, #([], render.empty_details), fn(acc, arg) {
-      let rendered = render(arg, arg_context)
-      #([rendered.doc, ..acc.0], render.merge_details(rendered.details, acc.1))
-    })
+  let #(rendered_args, details) = render_expressions(args, arg_context)
   let caller = render(func, context)
-  doc.concat([caller.doc, render.pretty_list(list.reverse(rendered_args))])
+  doc.concat([caller.doc, render.pretty_list(rendered_args)])
   |> render.Render(details: render.merge_details(details, caller.details))
 }
 

--- a/src/gleamgen/expression.gleam
+++ b/src/gleamgen/expression.gleam
@@ -1233,10 +1233,7 @@ fn render_call(func, args, context) {
 ///
 /// - `{ let x = ...; ... }` stays a block argument
 /// - `{ expr }` is simplified to `expr`
-fn render_call_argument(
-  arg: Expression(types.Dynamic),
-  context: render.Context,
-) {
+fn render_call_argument(arg: Expression(types.Dynamic), context: render.Context) {
   case arg.internal {
     // A block that only contains a returned expression can be passed directly.
     Block([ExpressionStatement(expr)]) -> render(expr, context)

--- a/src/gleamgen/expression.gleam
+++ b/src/gleamgen/expression.gleam
@@ -1153,22 +1153,28 @@ pub fn render_statement(statement: Statement, context) -> render.Rendered {
 fn render_block(statements, context) {
   let corrected_statements = remove_incorrect_empty_lines(statements)
 
+  // A block that only contains one expression does not need `{ ... }`; same
+  // rule as for call arguments (e.g. `let y = x + 1` not `let y = { x + 1 }`).
+  case corrected_statements {
+    [ExpressionStatement(expr)] ->
+      render(
+        expr,
+        render.Context(..context, include_brackets_current_level: True),
+      )
+    _ -> render_block_multi_statement(corrected_statements, context)
+  }
+}
+
+fn render_block_multi_statement(statements, context) {
   let #(inner_statements, details) =
-    list.fold(
-      corrected_statements,
-      #([], render.empty_details),
-      fn(acc, statement) {
-        let rendered =
-          render_statement(
-            statement,
-            render.Context(..context, include_brackets_current_level: True),
-          )
-        #(
-          [rendered.doc, ..acc.0],
-          render.merge_details(rendered.details, acc.1),
+    list.fold(statements, #([], render.empty_details), fn(acc, statement) {
+      let rendered =
+        render_statement(
+          statement,
+          render.Context(..context, include_brackets_current_level: True),
         )
-      },
-    )
+      #([rendered.doc, ..acc.0], render.merge_details(rendered.details, acc.1))
+    })
 
   let inner =
     inner_statements
@@ -1212,39 +1218,22 @@ fn render_expressions(
   #(rendered |> list.reverse(), details)
 }
 
-/// Render a call expression while handling block arguments context-sensitively.
-///
-/// Multi-statement blocks must stay wrapped in `{ ... }` when passed as call
-/// arguments, while single direct-return blocks can be unwrapped.
 fn render_call(func, args, context) {
+  // Arguments use bracket semantics at the root so multi-statement blocks stay
+  // wrapped even when this call is rendered with `include_brackets_current_level: False`
+  // (e.g. as a function body).
+  let arg_context =
+    render.Context(..context, include_brackets_current_level: True)
   // We build `rendered_args` in reverse via prepending for efficiency:
   // args [a, b] -> acc [b_doc, a_doc], then reverse before pretty_list.
   let #(rendered_args, details) =
     list.fold(args, #([], render.empty_details), fn(acc, arg) {
-      let rendered = render_call_argument(arg, context)
+      let rendered = render(arg, arg_context)
       #([rendered.doc, ..acc.0], render.merge_details(rendered.details, acc.1))
     })
   let caller = render(func, context)
   doc.concat([caller.doc, render.pretty_list(list.reverse(rendered_args))])
   |> render.Render(details: render.merge_details(details, caller.details))
-}
-
-/// Render one call argument and preserve semantics for block arguments.
-///
-/// - `{ let x = ...; ... }` stays a block argument
-/// - `{ expr }` is simplified to `expr`
-fn render_call_argument(arg: Expression(types.Dynamic), context: render.Context) {
-  case arg.internal {
-    // A block that only contains a returned expression can be passed directly.
-    Block([ExpressionStatement(expr)]) -> render(expr, context)
-    // Any larger block needs explicit braces when used as a call argument.
-    Block(_) ->
-      render(
-        arg,
-        render.Context(..context, include_brackets_current_level: True),
-      )
-    _ -> render(arg, context)
-  }
 }
 
 fn render_constructor(func, context) {

--- a/src/gleamgen/expression.gleam
+++ b/src/gleamgen/expression.gleam
@@ -1212,11 +1212,42 @@ fn render_expressions(
   #(rendered |> list.reverse(), details)
 }
 
+/// Render a call expression while handling block arguments context-sensitively.
+///
+/// Multi-statement blocks must stay wrapped in `{ ... }` when passed as call
+/// arguments, while single direct-return blocks can be unwrapped.
 fn render_call(func, args, context) {
-  let #(rendered_args, details) = render_expressions(args, context)
+  // We build `rendered_args` in reverse via prepending for efficiency:
+  // args [a, b] -> acc [b_doc, a_doc], then reverse before pretty_list.
+  let #(rendered_args, details) =
+    list.fold(args, #([], render.empty_details), fn(acc, arg) {
+      let rendered = render_call_argument(arg, context)
+      #([rendered.doc, ..acc.0], render.merge_details(rendered.details, acc.1))
+    })
   let caller = render(func, context)
-  doc.concat([caller.doc, render.pretty_list(rendered_args)])
+  doc.concat([caller.doc, render.pretty_list(list.reverse(rendered_args))])
   |> render.Render(details: render.merge_details(details, caller.details))
+}
+
+/// Render one call argument and preserve semantics for block arguments.
+///
+/// - `{ let x = ...; ... }` stays a block argument
+/// - `{ expr }` is simplified to `expr`
+fn render_call_argument(
+  arg: Expression(types.Dynamic),
+  context: render.Context,
+) {
+  case arg.internal {
+    // A block that only contains a returned expression can be passed directly.
+    Block([ExpressionStatement(expr)]) -> render(expr, context)
+    // Any larger block needs explicit braces when used as a call argument.
+    Block(_) ->
+      render(
+        arg,
+        render.Context(..context, include_brackets_current_level: True),
+      )
+    _ -> render(arg, context)
+  }
 }
 
 fn render_constructor(func, context) {

--- a/src/gleamgen/import_.gleam
+++ b/src/gleamgen/import_.gleam
@@ -8,12 +8,19 @@ import gleamgen/function
 import gleamgen/types
 import gleamgen/types/custom
 
+/// One entry in an `import path.{ … }` exposing list.
+pub type ExposedItem {
+  /// Renders as `type name` or `type name as alias`.
+  ExposedType(name: String, alias: Option(String))
+  /// Renders as `name` or `name as alias`.
+  ExposedValue(name: String, alias: Option(String))
+}
+
 pub type ImportedModule {
   ImportedModule(
     name: List(String),
     alias: Option(String),
-    /// When set, rendered as `import path.{inner}` (no braces in this string).
-    exposing: Option(String),
+    exposing: List(ExposedItem),
     before_text: String,
     predefined: Bool,
   )
@@ -23,86 +30,46 @@ pub fn new(name: List(String)) -> ImportedModule {
   ImportedModule(
     name: name,
     alias: option.None,
-    exposing: option.None,
+    exposing: [],
     before_text: "",
     predefined: False,
   )
 }
 
-pub fn new_with_alias(name: List(String), alias: String) -> ImportedModule {
-  ImportedModule(
-    name: name,
-    alias: option.Some(alias),
-    exposing: option.None,
-    before_text: "",
-    predefined: False,
-  )
+pub fn with_alias(imported: ImportedModule, alias: String) -> ImportedModule {
+  ImportedModule(..imported, alias: option.Some(alias))
 }
 
-/// Import with a Gleam exposing list, e.g. `new_with_exposing(["a", "b"], "type T, x")`
-/// renders `import a/b.{type T, x}`.
-pub fn new_with_exposing(name: List(String), exposing: String) -> ImportedModule {
-  ImportedModule(
-    name: name,
-    alias: option.None,
-    exposing: option.Some(exposing),
-    before_text: "",
-    predefined: False,
-  )
-}
-
-/// Import is always emitted (even if the module reference is not found in rendered bodies).
-/// Use for transitive dependencies of embedded expressions (e.g. `cake/select` inside a sub-AST).
-pub fn new_predefined(name: List(String)) -> ImportedModule {
-  ImportedModule(
-    name: name,
-    alias: option.None,
-    exposing: option.None,
-    before_text: "",
-    predefined: True,
-  )
-}
-
-/// Like [`new_predefined`](#new_predefined) but with `as alias` (import always emitted).
-pub fn new_predefined_with_alias(
-  name: List(String),
-  alias: String,
+pub fn with_exposing(
+  imported: ImportedModule,
+  exposing: List(ExposedItem),
 ) -> ImportedModule {
-  ImportedModule(
-    name: name,
-    alias: option.Some(alias),
-    exposing: option.None,
-    before_text: "",
-    predefined: True,
-  )
+  ImportedModule(..imported, exposing: exposing)
 }
 
-/// Like [`new_predefined`](#new_predefined) but with `.{exposing}` (import always emitted).
-pub fn new_predefined_with_exposing(
-  name: List(String),
-  exposing: String,
+/// When `True`, the import line is always emitted even if static analysis finds
+/// no reference to the module prefix (e.g. types only nested inside other ASTs).
+pub fn with_predefined(
+  imported: ImportedModule,
+  predefined: Bool,
 ) -> ImportedModule {
-  ImportedModule(
-    name: name,
-    alias: option.None,
-    exposing: option.Some(exposing),
-    before_text: "",
-    predefined: True,
-  )
+  ImportedModule(..imported, predefined: predefined)
 }
 
-pub fn new_with_alias_and_exposing(
-  name: List(String),
-  alias: String,
-  exposing: String,
-) -> ImportedModule {
-  ImportedModule(
-    name: name,
-    alias: option.Some(alias),
-    exposing: option.Some(exposing),
-    before_text: "",
-    predefined: False,
-  )
+pub fn exposed_type(name: String) -> ExposedItem {
+  ExposedType(name, option.None)
+}
+
+pub fn exposed_type_as(name: String, alias: String) -> ExposedItem {
+  ExposedType(name, option.Some(alias))
+}
+
+pub fn exposed_value(name: String) -> ExposedItem {
+  ExposedValue(name, option.None)
+}
+
+pub fn exposed_value_as(name: String, alias: String) -> ExposedItem {
+  ExposedValue(name, option.Some(alias))
 }
 
 @internal
@@ -290,7 +257,7 @@ pub fn convert_import(
   ImportedModule(
     name:,
     alias: alias,
-    exposing: option.None,
+    exposing: [],
     before_text: before_import,
     predefined: True,
   )
@@ -311,14 +278,63 @@ pub fn merge_imports(imports) {
   do_merge_imports(imports, option.None, [])
 }
 
-/// Combine exposing clauses when `merge_imports` collapses duplicate module paths.
-fn merge_exposing(a: Option(String), b: Option(String)) -> Option(String) {
+fn compare_optional_string(a: Option(String), b: Option(String)) -> order.Order {
   case a, b {
-    option.None, option.None -> option.None
-    option.Some(x), option.None -> option.Some(x)
-    option.None, option.Some(y) -> option.Some(y)
-    option.Some(x), option.Some(y) -> option.Some(x <> ", " <> y)
+    option.None, option.None -> order.Eq
+    option.None, option.Some(_) -> order.Lt
+    option.Some(_), option.None -> order.Gt
+    option.Some(x), option.Some(y) -> string.compare(x, y)
   }
+}
+
+fn compare_exposed_item(a: ExposedItem, b: ExposedItem) -> order.Order {
+  case a, b {
+    ExposedType(..), ExposedValue(..) -> order.Lt
+    ExposedValue(..), ExposedType(..) -> order.Gt
+    ExposedType(n1, a1), ExposedType(n2, a2) ->
+      case string.compare(n1, n2) {
+        order.Eq -> compare_optional_string(a1, a2)
+        o -> o
+      }
+    ExposedValue(n1, a1), ExposedValue(n2, a2) ->
+      case string.compare(n1, n2) {
+        order.Eq -> compare_optional_string(a1, a2)
+        o -> o
+      }
+  }
+}
+
+fn render_exposed_item(item: ExposedItem) -> String {
+  case item {
+    ExposedType(name, alias) ->
+      case alias {
+        option.None -> "type " <> name
+        option.Some(a) -> "type " <> name <> " as " <> a
+      }
+    ExposedValue(name, alias) ->
+      case alias {
+        option.None -> name
+        option.Some(a) -> name <> " as " <> a
+      }
+  }
+}
+
+@internal
+pub fn exposing_to_string(items: List(ExposedItem)) -> String {
+  items
+  |> list.map(render_exposed_item)
+  |> string.join(", ")
+}
+
+/// Combine exposing lists when `merge_imports` collapses duplicate module paths
+/// (sorted and deduplicated).
+fn merge_exposing_lists(
+  a: List(ExposedItem),
+  b: List(ExposedItem),
+) -> List(ExposedItem) {
+  list.append(a, b)
+  |> list.sort(compare_exposed_item)
+  |> list.unique
 }
 
 fn do_merge_imports(
@@ -336,7 +352,7 @@ fn do_merge_imports(
             option.None, option.Some(a) -> option.Some(a)
             option.None, option.None -> option.None
           },
-          exposing: merge_exposing(last.exposing, import_.exposing),
+          exposing: merge_exposing_lists(last.exposing, import_.exposing),
           before_text: last.before_text <> import_.before_text,
           predefined: last.predefined || import_.predefined,
         )

--- a/src/gleamgen/import_.gleam
+++ b/src/gleamgen/import_.gleam
@@ -12,6 +12,8 @@ pub type ImportedModule {
   ImportedModule(
     name: List(String),
     alias: Option(String),
+    /// When set, rendered as `import path.{inner}` (no braces in this string).
+    exposing: Option(String),
     before_text: String,
     predefined: Bool,
   )
@@ -21,6 +23,7 @@ pub fn new(name: List(String)) -> ImportedModule {
   ImportedModule(
     name: name,
     alias: option.None,
+    exposing: option.None,
     before_text: "",
     predefined: False,
   )
@@ -30,6 +33,33 @@ pub fn new_with_alias(name: List(String), alias: String) -> ImportedModule {
   ImportedModule(
     name: name,
     alias: option.Some(alias),
+    exposing: option.None,
+    before_text: "",
+    predefined: False,
+  )
+}
+
+/// Import with a Gleam exposing list, e.g. `new_with_exposing(["a", "b"], "type T, x")`
+/// renders `import a/b.{type T, x}`.
+pub fn new_with_exposing(name: List(String), exposing: String) -> ImportedModule {
+  ImportedModule(
+    name: name,
+    alias: option.None,
+    exposing: option.Some(exposing),
+    before_text: "",
+    predefined: False,
+  )
+}
+
+pub fn new_with_alias_and_exposing(
+  name: List(String),
+  alias: String,
+  exposing: String,
+) -> ImportedModule {
+  ImportedModule(
+    name: name,
+    alias: option.Some(alias),
+    exposing: option.Some(exposing),
     before_text: "",
     predefined: False,
   )
@@ -220,6 +250,7 @@ pub fn convert_import(
   ImportedModule(
     name:,
     alias: alias,
+    exposing: option.None,
     before_text: before_import,
     predefined: True,
   )
@@ -240,6 +271,19 @@ pub fn merge_imports(imports) {
   do_merge_imports(imports, option.None, [])
 }
 
+/// Combine exposing clauses when `merge_imports` collapses duplicate module paths.
+fn merge_exposing(
+  a: Option(String),
+  b: Option(String),
+) -> Option(String) {
+  case a, b {
+    option.None, option.None -> option.None
+    option.Some(x), option.None -> option.Some(x)
+    option.None, option.Some(y) -> option.Some(y)
+    option.Some(x), option.Some(y) -> option.Some(x <> ", " <> y)
+  }
+}
+
 fn do_merge_imports(
   imports_left: List(ImportedModule),
   last_import: Option(ImportedModule),
@@ -255,6 +299,7 @@ fn do_merge_imports(
             option.None, option.Some(a) -> option.Some(a)
             option.None, option.None -> option.None
           },
+          exposing: merge_exposing(last.exposing, import_.exposing),
           before_text: last.before_text <> import_.before_text,
           predefined: last.predefined || import_.predefined,
         )

--- a/src/gleamgen/import_.gleam
+++ b/src/gleamgen/import_.gleam
@@ -64,7 +64,10 @@ pub fn new_predefined(name: List(String)) -> ImportedModule {
 }
 
 /// Like [`new_predefined`](#new_predefined) but with `as alias` (import always emitted).
-pub fn new_predefined_with_alias(name: List(String), alias: String) -> ImportedModule {
+pub fn new_predefined_with_alias(
+  name: List(String),
+  alias: String,
+) -> ImportedModule {
   ImportedModule(
     name: name,
     alias: option.Some(alias),
@@ -75,7 +78,10 @@ pub fn new_predefined_with_alias(name: List(String), alias: String) -> ImportedM
 }
 
 /// Like [`new_predefined`](#new_predefined) but with `.{exposing}` (import always emitted).
-pub fn new_predefined_with_exposing(name: List(String), exposing: String) -> ImportedModule {
+pub fn new_predefined_with_exposing(
+  name: List(String),
+  exposing: String,
+) -> ImportedModule {
   ImportedModule(
     name: name,
     alias: option.None,
@@ -306,10 +312,7 @@ pub fn merge_imports(imports) {
 }
 
 /// Combine exposing clauses when `merge_imports` collapses duplicate module paths.
-fn merge_exposing(
-  a: Option(String),
-  b: Option(String),
-) -> Option(String) {
+fn merge_exposing(a: Option(String), b: Option(String)) -> Option(String) {
   case a, b {
     option.None, option.None -> option.None
     option.Some(x), option.None -> option.Some(x)

--- a/src/gleamgen/import_.gleam
+++ b/src/gleamgen/import_.gleam
@@ -51,6 +51,40 @@ pub fn new_with_exposing(name: List(String), exposing: String) -> ImportedModule
   )
 }
 
+/// Import is always emitted (even if the module reference is not found in rendered bodies).
+/// Use for transitive dependencies of embedded expressions (e.g. `cake/select` inside a sub-AST).
+pub fn new_predefined(name: List(String)) -> ImportedModule {
+  ImportedModule(
+    name: name,
+    alias: option.None,
+    exposing: option.None,
+    before_text: "",
+    predefined: True,
+  )
+}
+
+/// Like [`new_predefined`](#new_predefined) but with `as alias` (import always emitted).
+pub fn new_predefined_with_alias(name: List(String), alias: String) -> ImportedModule {
+  ImportedModule(
+    name: name,
+    alias: option.Some(alias),
+    exposing: option.None,
+    before_text: "",
+    predefined: True,
+  )
+}
+
+/// Like [`new_predefined`](#new_predefined) but with `.{exposing}` (import always emitted).
+pub fn new_predefined_with_exposing(name: List(String), exposing: String) -> ImportedModule {
+  ImportedModule(
+    name: name,
+    alias: option.None,
+    exposing: option.Some(exposing),
+    before_text: "",
+    predefined: True,
+  )
+}
+
 pub fn new_with_alias_and_exposing(
   name: List(String),
   alias: String,

--- a/src/gleamgen/module.gleam
+++ b/src/gleamgen/module.gleam
@@ -628,26 +628,6 @@ pub fn eof() -> Module {
   Module([], [], option.None)
 }
 
-/// `merge_imports` only collapses adjacent same-path imports; drop later copies
-/// of the same module path (first wins; exposing/alias should match via merge).
-fn dedupe_imports_by_path(
-  imports: List(import_.ImportedModule),
-) -> List(import_.ImportedModule) {
-  list.reverse(
-    list.fold(imports, [], fn(acc, imp) {
-      let path = string.join(imp.name, "/")
-      case
-        list.any(acc, fn(existing: import_.ImportedModule) {
-          string.join(existing.name, "/") == path
-        })
-      {
-        True -> acc
-        False -> [imp, ..acc]
-      }
-    }),
-  )
-}
-
 pub fn render(module: Module, context: render.Context) -> render.Rendered {
   let #(definitions_at_top, definitions_at_bottom, definitions_after) =
     separate_definitions(module.definitions, [], [], dict.new())
@@ -680,13 +660,12 @@ pub fn render(module: Module, context: render.Context) -> render.Rendered {
     |> list.filter(fn(m) {
       m.predefined
       // Explicit `.{…}` imports must appear even if nothing references the module prefix.
-      || option.is_some(m.exposing)
+      || !list.is_empty(m.exposing)
       || details.used_imports
       |> list.contains(import_.get_reference(m))
     })
     |> list.sort(import_.compare)
     |> import_.merge_imports
-    |> dedupe_imports_by_path
     |> list.map(fn(x) { x |> render_imported_module |> render.to_string() })
     |> list.map(doc.from_string)
     |> doc.join(with: doc.line)
@@ -707,13 +686,13 @@ pub fn render_imported_module(module: import_.ImportedModule) -> render.Rendered
     doc.from_string("import "),
     doc.from_string(string.join(module.name, "/")),
     case module.exposing {
-      option.Some(inner) ->
+      [] -> doc.empty
+      exposing ->
         doc.concat([
           doc.from_string(".{"),
-          doc.from_string(inner),
+          doc.from_string(import_.exposing_to_string(exposing)),
           doc.from_string("}"),
         ])
-      option.None -> doc.empty
     },
     case module.alias {
       option.Some(alias) ->

--- a/src/gleamgen/module.gleam
+++ b/src/gleamgen/module.gleam
@@ -659,6 +659,8 @@ pub fn render(module: Module, context: render.Context) -> render.Rendered {
     module.imports
     |> list.filter(fn(m) {
       m.predefined
+      // Explicit `.{…}` imports must appear even if nothing references the module prefix.
+      || option.is_some(m.exposing)
       || details.used_imports
       |> list.contains(import_.get_reference(m))
     })
@@ -678,10 +680,20 @@ pub fn render(module: Module, context: render.Context) -> render.Rendered {
 }
 
 pub fn render_imported_module(module: import_.ImportedModule) -> render.Rendered {
+  // Gleam syntax is `import path.{items} as alias`, not `import path as alias.{items}`.
   doc.concat([
     doc.from_string(module.before_text),
     doc.from_string("import "),
     doc.from_string(string.join(module.name, "/")),
+    case module.exposing {
+      option.Some(inner) ->
+        doc.concat([
+          doc.from_string(".{"),
+          doc.from_string(inner),
+          doc.from_string("}"),
+        ])
+      option.None -> doc.empty
+    },
     case module.alias {
       option.Some(alias) ->
         doc.concat([

--- a/src/gleamgen/module.gleam
+++ b/src/gleamgen/module.gleam
@@ -628,6 +628,26 @@ pub fn eof() -> Module {
   Module([], [], option.None)
 }
 
+/// `merge_imports` only collapses adjacent same-path imports; drop later copies
+/// of the same module path (first wins; exposing/alias should match via merge).
+fn dedupe_imports_by_path(
+  imports: List(import_.ImportedModule),
+) -> List(import_.ImportedModule) {
+  list.reverse(
+    list.fold(imports, [], fn(acc, imp) {
+      let path = string.join(imp.name, "/")
+      case
+        list.any(acc, fn(existing: import_.ImportedModule) {
+          string.join(existing.name, "/") == path
+        })
+      {
+        True -> acc
+        False -> [imp, ..acc]
+      }
+    }),
+  )
+}
+
 pub fn render(module: Module, context: render.Context) -> render.Rendered {
   let #(definitions_at_top, definitions_at_bottom, definitions_after) =
     separate_definitions(module.definitions, [], [], dict.new())
@@ -666,6 +686,7 @@ pub fn render(module: Module, context: render.Context) -> render.Rendered {
     })
     |> list.sort(import_.compare)
     |> import_.merge_imports
+    |> dedupe_imports_by_path
     |> list.map(fn(x) { x |> render_imported_module |> render.to_string() })
     |> list.map(doc.from_string)
     |> doc.join(with: doc.line)

--- a/src/gleamgen/parameter.gleam
+++ b/src/gleamgen/parameter.gleam
@@ -73,7 +73,9 @@ pub fn render_parameters(
   )
 }
 
-fn parameter_type_details(param: Parameter(types.Dynamic)) -> render.RenderedDetails {
+fn parameter_type_details(
+  param: Parameter(types.Dynamic),
+) -> render.RenderedDetails {
   types.render_type(type_(param))
   |> result.map(fn(r) { r.details })
   |> result.unwrap(render.empty_details)
@@ -115,8 +117,7 @@ fn do_render_parameters(
         }
       }
 
-      let details =
-        render.merge_details(type_details_acc, label_details)
+      let details = render.merge_details(type_details_acc, label_details)
 
       render.Render(doc, details)
     }

--- a/src/gleamgen/parameter.gleam
+++ b/src/gleamgen/parameter.gleam
@@ -1,6 +1,7 @@
 import glam/doc
 import gleam/list
 import gleam/option
+import gleam/result
 import gleamgen/internal/render
 import gleamgen/render/report
 import gleamgen/types
@@ -61,7 +62,21 @@ pub fn render_parameters(
   include_labels include_labels: Bool,
   context context: render.Context,
 ) {
-  do_render_parameters(parameters, [], False, [], include_labels, context)
+  do_render_parameters(
+    parameters,
+    [],
+    False,
+    [],
+    render.empty_details,
+    include_labels,
+    context,
+  )
+}
+
+fn parameter_type_details(param: Parameter(types.Dynamic)) -> render.RenderedDetails {
+  types.render_type(type_(param))
+  |> result.map(fn(r) { r.details })
+  |> result.unwrap(render.empty_details)
 }
 
 fn do_render_parameters(
@@ -69,6 +84,7 @@ fn do_render_parameters(
   acc: List(doc.Document),
   last_parameter_had_label: Bool,
   should_have_been_labeled_params: List(String),
+  type_details_acc: render.RenderedDetails,
   include_labels include_labels: Bool,
   context context: render.Context,
 ) -> render.Rendered {
@@ -76,7 +92,7 @@ fn do_render_parameters(
     [] -> {
       let doc = render.pretty_list(list.reverse(acc))
 
-      let details = case should_have_been_labeled_params {
+      let label_details = case should_have_been_labeled_params {
         [] -> render.empty_details
         not_labeled if context.config.auto_fix_parameters -> {
           render.RenderedDetails(
@@ -99,10 +115,15 @@ fn do_render_parameters(
         }
       }
 
+      let details =
+        render.merge_details(type_details_acc, label_details)
+
       render.Render(doc, details)
     }
     [param, ..rest] -> {
       let has_label = option.is_some(param.label)
+      let next_type_details =
+        render.merge_details(type_details_acc, parameter_type_details(param))
       case has_label {
         True ->
           do_render_parameters(
@@ -110,6 +131,7 @@ fn do_render_parameters(
             [render(param, include_labels, context), ..acc],
             True,
             should_have_been_labeled_params,
+            next_type_details,
             include_labels,
             context,
           )
@@ -118,11 +140,17 @@ fn do_render_parameters(
             True -> with_label(param, param.name)
             False -> param
           }
+          let merged_details =
+            render.merge_details(
+              type_details_acc,
+              parameter_type_details(fixed_parameter),
+            )
           do_render_parameters(
             rest,
             [render(fixed_parameter, include_labels, context), ..acc],
             True,
             [param.name, ..should_have_been_labeled_params],
+            merged_details,
             include_labels,
             context,
           )
@@ -133,6 +161,7 @@ fn do_render_parameters(
             [render(param, include_labels, context), ..acc],
             last_parameter_had_label,
             should_have_been_labeled_params,
+            next_type_details,
             include_labels,
             context,
           )

--- a/src/gleamgen/pattern.gleam
+++ b/src/gleamgen/pattern.gleam
@@ -826,18 +826,12 @@ pub fn list_empty() -> Pattern(List(a), Nil) {
 
 /// Renders `[first, ..]` and binds the head element to `first`.
 pub fn list_first_discard_rest(first: String) -> Pattern(List(a), Expression(a)) {
-  Constructor(
-    #("[" <> first <> ", ..]", []),
-    output: expression.raw(first),
-  )
+  Constructor(#("[" <> first <> ", ..]", []), output: expression.raw(first))
 }
 
 /// Renders `[..name]` and binds the whole list to `name`.
 pub fn list_spread(name: String) -> Pattern(List(a), Expression(List(a))) {
-  Constructor(
-    #("[.." <> name <> "]", []),
-    output: expression.raw(name),
-  )
+  Constructor(#("[.." <> name <> "]", []), output: expression.raw(name))
 }
 
 /// Match `VariantName(p1, p2, …)` when the variant comes from another module.
@@ -856,10 +850,7 @@ pub fn foreign_variant(
 
 /// `Some(inner)`.
 pub fn option_some(inner: Pattern(a, a_out)) -> Pattern(types.Dynamic, a_out) {
-  Constructor(
-    #("Some", [inner |> to_dynamic]),
-    output: inner.output,
-  )
+  Constructor(#("Some", [inner |> to_dynamic]), output: inner.output)
 }
 
 /// `None`.

--- a/src/gleamgen/pattern.gleam
+++ b/src/gleamgen/pattern.gleam
@@ -824,6 +824,14 @@ pub fn list_empty() -> Pattern(List(a), Nil) {
   Constructor(#("[]", []), output: Nil)
 }
 
+/// Renders `[first, ..]` and binds the head element to `first`.
+pub fn list_first_discard_rest(first: String) -> Pattern(List(a), Expression(a)) {
+  Constructor(
+    #("[" <> first <> ", ..]", []),
+    output: expression.raw(first),
+  )
+}
+
 /// Renders `[..name]` and binds the whole list to `name`.
 pub fn list_spread(name: String) -> Pattern(List(a), Expression(List(a))) {
   Constructor(

--- a/src/gleamgen/pattern.gleam
+++ b/src/gleamgen/pattern.gleam
@@ -1,6 +1,7 @@
 import glam/doc
 import gleam/int
 import gleam/list
+import gleam/option.{type Option}
 import gleamgen/expression.{type Expression}
 import gleamgen/expression/constructor
 import gleamgen/internal/render
@@ -819,7 +820,7 @@ pub fn can_match_on_multiple(pattern: Pattern(_, _)) -> Bool {
   }
 }
 
-/// Renders `[]`. Use before `list_spread` so the empty case matches first.
+/// Renders `[]`. List this branch before a catch-all (e.g. `variable`) so the empty case matches first.
 pub fn list_empty() -> Pattern(List(a), Nil) {
   Constructor(#("[]", []), output: Nil)
 }
@@ -827,11 +828,6 @@ pub fn list_empty() -> Pattern(List(a), Nil) {
 /// Renders `[first, ..]` and binds the head element to `first`.
 pub fn list_first_discard_rest(first: String) -> Pattern(List(a), Expression(a)) {
   Constructor(#("[" <> first <> ", ..]", []), output: expression.raw(first))
-}
-
-/// Renders `[..name]` and binds the whole list to `name`.
-pub fn list_spread(name: String) -> Pattern(List(a), Expression(List(a))) {
-  Constructor(#("[.." <> name <> "]", []), output: expression.raw(name))
 }
 
 /// Match `VariantName(p1, p2, …)` when the variant comes from another module.
@@ -849,12 +845,12 @@ pub fn foreign_variant(
 }
 
 /// `Some(inner)`.
-pub fn option_some(inner: Pattern(a, a_out)) -> Pattern(types.Dynamic, a_out) {
+pub fn option_some(inner: Pattern(a, a_out)) -> Pattern(Option(a), a_out) {
   Constructor(#("Some", [inner |> to_dynamic]), output: inner.output)
 }
 
 /// `None`.
-pub fn option_none() -> Pattern(types.Dynamic, Nil) {
+pub fn option_none() -> Pattern(Option(a), Nil) {
   Constructor(#("None", []), output: Nil)
 }
 // vim: foldmethod=marker foldlevel=0

--- a/src/gleamgen/pattern.gleam
+++ b/src/gleamgen/pattern.gleam
@@ -769,17 +769,24 @@ pub fn render(
       |> render.Render(details: original.details)
     }
     Constructor(#(name, patterns), ..) -> {
-      let #(details, rendered_patterns) =
-        patterns
-        |> list.map_fold(render.empty_details, fn(acc, m) {
-          let rendered = render(m, 1)
-          #(render.merge_details(acc, rendered.details), rendered.doc)
-        })
+      case patterns {
+        [] ->
+          doc.from_string(name)
+          |> render.Render(details: render.empty_details)
+        _ -> {
+          let #(details, rendered_patterns) =
+            patterns
+            |> list.map_fold(render.empty_details, fn(acc, m) {
+              let rendered = render(m, 1)
+              #(render.merge_details(acc, rendered.details), rendered.doc)
+            })
 
-      rendered_patterns
-      |> render.pretty_list()
-      |> doc.prepend(doc.from_string(name))
-      |> render.Render(details:)
+          rendered_patterns
+          |> render.pretty_list()
+          |> doc.prepend(doc.from_string(name))
+          |> render.Render(details:)
+        }
+      }
     }
     Tuple(patterns, ..) -> {
       let #(details, rendered_patterns) =
@@ -810,6 +817,19 @@ pub fn can_match_on_multiple(pattern: Pattern(_, _)) -> Bool {
     Variable(name: "_", ..) -> True
     _ -> False
   }
+}
+
+/// Renders `[]`. Use before `list_spread` so the empty case matches first.
+pub fn list_empty() -> Pattern(List(a), Nil) {
+  Constructor(#("[]", []), output: Nil)
+}
+
+/// Renders `[..name]` and binds the whole list to `name`.
+pub fn list_spread(name: String) -> Pattern(List(a), Expression(List(a))) {
+  Constructor(
+    #("[.." <> name <> "]", []),
+    output: expression.raw(name),
+  )
 }
 
 /// Match `VariantName(p1, p2, …)` when the variant comes from another module.

--- a/src/gleamgen/pattern.gleam
+++ b/src/gleamgen/pattern.gleam
@@ -811,4 +811,31 @@ pub fn can_match_on_multiple(pattern: Pattern(_, _)) -> Bool {
     _ -> False
   }
 }
+
+/// Match `VariantName(p1, p2, …)` when the variant comes from another module.
+/// Pass `pattern.variable(\"field\") |> pattern.to_dynamic` for each field in order.
+/// The case handler receives each field’s pattern output, typically
+/// `expression.raw(\"field\")`, as a list in left-to-right order.
+pub fn foreign_variant(
+  variant_name: String,
+  field_patterns: List(Pattern(types.Dynamic, types.Dynamic)),
+) -> Pattern(types.Dynamic, List(Expression(types.Dynamic))) {
+  Constructor(
+    #(variant_name, list.map(field_patterns, to_dynamic)),
+    output: list.filter_map(field_patterns, get_pattern_output),
+  )
+}
+
+/// `Some(inner)`.
+pub fn option_some(inner: Pattern(a, a_out)) -> Pattern(types.Dynamic, a_out) {
+  Constructor(
+    #("Some", [inner |> to_dynamic]),
+    output: inner.output,
+  )
+}
+
+/// `None`.
+pub fn option_none() -> Pattern(types.Dynamic, Nil) {
+  Constructor(#("None", []), output: Nil)
+}
 // vim: foldmethod=marker foldlevel=0

--- a/test/gleamgen_test.gleam
+++ b/test/gleamgen_test.gleam
@@ -1352,6 +1352,59 @@ pub fn call_with_block_argument_test() {
   assert direct_return == expected_direct_return
 }
 
+/// Regression test for list pattern helpers with zero-argument constructors.
+///
+/// Ensures `pattern.list_empty()` renders as `[]` (not `[]()`) and
+/// `pattern.list_spread("items")` renders as `[..items]`.
+pub fn case_with_list_empty_and_spread_pattern_test() {
+  let result =
+    case_.new(expression.list([]))
+    |> case_.with_pattern(pattern.list_empty(), fn(_) {
+      expression.string("empty")
+    })
+    |> case_.with_pattern(pattern.list_spread("items"), fn(_) {
+      expression.string("not empty")
+    })
+    |> case_.build_expression()
+    |> expression.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "case [] {
+  [] -> \"empty\"
+  [..items] -> \"not empty\"
+}"
+
+  assert result == expected
+}
+
+/// Regression test for option pattern helper rendering.
+///
+/// Ensures `pattern.option_some(...)` renders `Some(...)` and
+/// `pattern.option_none()` renders `None` (no zero-arg parentheses).
+pub fn case_with_option_pattern_helpers_test() {
+  let result =
+    case_.new(expression.raw("maybe_name"))
+    |> case_.with_pattern(
+      pattern.option_some(pattern.variable("name")),
+      fn(name) { expression.concat_string(name, expression.string("!")) },
+    )
+    |> case_.with_pattern(pattern.option_none(), fn(_) {
+      expression.string("anonymous")
+    })
+    |> case_.build_expression()
+    |> expression.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "case maybe_name {
+  Some(name) -> name <> \"!\"
+  None -> \"anonymous\"
+}"
+
+  assert result == expected
+}
+
 pub fn result_test() {
   let mod = {
     use result_module <- module.with_import(import_.new(["gleam", "result"]))

--- a/test/gleamgen_test.gleam
+++ b/test/gleamgen_test.gleam
@@ -1315,6 +1315,43 @@ pub fn do_result() -> Result(Int, String) {
   assert result == expected
 }
 
+/// Regression test for rendering block arguments in call expressions.
+///
+/// Ensures calls like `result.try(...)` keep braces for block arguments with
+/// `let` statements, while still unwrapping single direct-return blocks.
+pub fn call_with_block_argument_test() {
+  let with_let =
+    expression.call_dynamic(expression.raw("result.try"), [
+      expression.ok(expression.int(3)) |> expression.to_dynamic(),
+      block.with_let_declaration("next", expression.int(4), fn(next) {
+        expression.ok(next)
+      })
+      |> expression.to_dynamic(),
+    ])
+    |> expression.render(render.default_context())
+    |> render.to_string()
+
+  let expected_with_let =
+    "result.try(Ok(3), {
+    let next = 4
+    Ok(next)
+  })"
+
+  assert with_let == expected_with_let
+
+  let direct_return =
+    expression.call_dynamic(expression.raw("result.try"), [
+      expression.ok(expression.int(3)) |> expression.to_dynamic(),
+      block.new_dynamic([statement.expression(expression.ok(expression.int(4)))]),
+    ])
+    |> expression.render(render.default_context())
+    |> render.to_string()
+
+  let expected_direct_return = "result.try(Ok(3), Ok(4))"
+
+  assert direct_return == expected_direct_return
+}
+
 pub fn result_test() {
   let mod = {
     use result_module <- module.with_import(import_.new(["gleam", "result"]))

--- a/test/gleamgen_test.gleam
+++ b/test/gleamgen_test.gleam
@@ -1326,7 +1326,7 @@ pub fn call_with_block_argument_test() {
       block.with_let_declaration("next", expression.int(4), fn(next) {
         expression.ok(next)
       })
-      |> expression.to_dynamic(),
+        |> expression.to_dynamic(),
     ])
     |> expression.render(render.default_context())
     |> render.to_string()

--- a/test/gleamgen_test.gleam
+++ b/test/gleamgen_test.gleam
@@ -1348,12 +1348,12 @@ pub fn single_expression_block_in_let_value_test() {
 
 /// Regression test for rendering block arguments in call expressions.
 ///
-/// Ensures calls like `result.try(...)` keep braces for block arguments with
+/// Ensures calls like `result.or(...)` keep braces for block arguments with
 /// `let` statements, while still unwrapping single-expression blocks (via
 /// `render_block`).
 pub fn call_with_block_argument_test() {
   let with_let =
-    expression.call_dynamic(expression.raw("result.try"), [
+    expression.call_dynamic(expression.raw("result.or"), [
       expression.ok(expression.int(3)) |> expression.to_dynamic(),
       block.with_let_declaration("next", expression.int(4), fn(next) {
         expression.ok(next)
@@ -1364,7 +1364,7 @@ pub fn call_with_block_argument_test() {
     |> render.to_string()
 
   let expected_with_let =
-    "result.try(Ok(3), {
+    "result.or(Ok(3), {
     let next = 4
     Ok(next)
   })"
@@ -1372,29 +1372,29 @@ pub fn call_with_block_argument_test() {
   assert with_let == expected_with_let
 
   let direct_return =
-    expression.call_dynamic(expression.raw("result.try"), [
+    expression.call_dynamic(expression.raw("result.or"), [
       expression.ok(expression.int(3)) |> expression.to_dynamic(),
       block.new_dynamic([statement.expression(expression.ok(expression.int(4)))]),
     ])
     |> expression.render(render.default_context())
     |> render.to_string()
 
-  let expected_direct_return = "result.try(Ok(3), Ok(4))"
+  let expected_direct_return = "result.or(Ok(3), Ok(4))"
 
   assert direct_return == expected_direct_return
 }
 
 /// Regression test for list pattern helpers with zero-argument constructors.
 ///
-/// Ensures `pattern.list_empty()` renders as `[]` (not `[]()`) and
-/// `pattern.list_spread("items")` renders as `[..items]`.
+/// Ensures `pattern.list_empty()` renders as `[]` (not `[]()`), and that a
+/// variable pattern matches a non-empty list branch after the empty list arm.
 pub fn case_with_list_empty_and_spread_pattern_test() {
   let result =
     case_.new(expression.list([]))
     |> case_.with_pattern(pattern.list_empty(), fn(_) {
       expression.string("empty")
     })
-    |> case_.with_pattern(pattern.list_spread("items"), fn(_) {
+    |> case_.with_pattern(pattern.variable("items"), fn(_) {
       expression.string("not empty")
     })
     |> case_.build_expression()
@@ -1404,7 +1404,7 @@ pub fn case_with_list_empty_and_spread_pattern_test() {
   let expected =
     "case [] {
   [] -> \"empty\"
-  [..items] -> \"not empty\"
+  items -> \"not empty\"
 }"
 
   assert result == expected
@@ -1549,10 +1549,9 @@ pub fn runner(thing: AwesomeString) -> String {
 
 pub fn module_import_test() {
   let mod = {
-    use io <- module.with_import(import_.new_with_alias(
-      ["gleam", "io"],
-      "only_o",
-    ))
+    use io <- module.with_import(
+      import_.new(["gleam", "io"]) |> import_.with_alias("only_o"),
+    )
     use int_mod <- module.with_import(import_.new(["gleam", "int"]))
 
     let io_print = import_.function1(io, io.println)
@@ -1592,14 +1591,14 @@ pub fn main() -> Nil {
   assert result == expected
 }
 
-/// Regression test for `import_.new_with_exposing`: rendered `import path.{items}` and kept in output
+/// Regression test for `import_.with_exposing`: rendered `import path.{items}` and kept in output
 /// when nothing references the module prefix (only unqualified imports from the exposing list).
 pub fn module_import_with_exposing_test() {
   let mod = {
-    use _string <- module.with_import(import_.new_with_exposing(
-      ["gleam", "string"],
-      "length",
-    ))
+    use _string <- module.with_import(
+      import_.new(["gleam", "string"])
+      |> import_.with_exposing([import_.exposed_value("length")]),
+    )
 
     use _main <- module.with_function(
       definition.new(name: "main")
@@ -1627,11 +1626,11 @@ pub fn main() -> Nil {
 /// `import path.{items} as alias` — exposing must come before `as` in Gleam syntax.
 pub fn module_import_with_alias_and_exposing_test() {
   let mod = {
-    use io <- module.with_import(import_.new_with_alias_and_exposing(
-      ["gleam", "io"],
-      "only_o",
-      "println",
-    ))
+    use io <- module.with_import(
+      import_.new(["gleam", "io"])
+      |> import_.with_exposing([import_.exposed_value("println")])
+      |> import_.with_alias("only_o"),
+    )
 
     let io_print = import_.function1(io, io.println)
 
@@ -1660,17 +1659,17 @@ pub fn main() -> Nil {
   assert result == expected
 }
 
-/// Duplicate module paths with separate exposing lists merge into one import (stable order).
+/// Duplicate module paths with separate exposing lists merge into one import (sorted, deduped).
 pub fn module_merge_imports_exposing_test() {
   let mod = {
-    use _ <- module.with_import(import_.new_with_exposing(
-      ["gleam", "string"],
-      "reverse",
-    ))
-    use _ <- module.with_import(import_.new_with_exposing(
-      ["gleam", "string"],
-      "length",
-    ))
+    use _ <- module.with_import(
+      import_.new(["gleam", "string"])
+      |> import_.with_exposing([import_.exposed_value("reverse")]),
+    )
+    use _ <- module.with_import(
+      import_.new(["gleam", "string"])
+      |> import_.with_exposing([import_.exposed_value("length")]),
+    )
 
     use _main <- module.with_function(
       definition.new(name: "main")
@@ -1686,7 +1685,42 @@ pub fn module_merge_imports_exposing_test() {
     |> render.to_string()
 
   let expected =
-    "import gleam/string.{reverse, length}
+    "import gleam/string.{length, reverse}
+
+pub fn main() -> Nil {
+  Nil
+}"
+
+  assert result == expected
+}
+
+/// Merging imports with overlapping exposing lists deduplicates entries.
+pub fn module_merge_imports_exposing_dedupes_test() {
+  let mod = {
+    use _ <- module.with_import(
+      import_.new(["gleam", "string"])
+        |> import_.with_exposing([import_.exposed_value("length")]),
+    )
+    use _ <- module.with_import(
+      import_.new(["gleam", "string"])
+        |> import_.with_exposing([import_.exposed_value("length")]),
+    )
+
+    use _main <- module.with_function(
+      definition.new(name: "main")
+        |> definition.with_publicity(True),
+      function.new0(returns: types.nil, handler: fn() { expression.nil() }),
+    )
+    module.eof()
+  }
+
+  let result =
+    mod
+    |> module.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "import gleam/string.{length}
 
 pub fn main() -> Nil {
   Nil
@@ -1697,10 +1731,9 @@ pub fn main() -> Nil {
 
 pub fn module_unused_import_test() {
   let mod = {
-    use io <- module.with_import(import_.new_with_alias(
-      ["gleam", "io"],
-      "only_o",
-    ))
+    use io <- module.with_import(
+      import_.new(["gleam", "io"]) |> import_.with_alias("only_o"),
+    )
     use int_mod <- module.with_import(import_.new(["gleam", "int"]))
     use _ <- module.with_import(import_.new(["gleam", "string"]))
 
@@ -1747,10 +1780,9 @@ const use_string_mod_this_time = False
 
 pub fn module_sometimes_unused_import_test() {
   let mod = {
-    use io <- module.with_import(import_.new_with_alias(
-      ["gleam", "io"],
-      "only_o",
-    ))
+    use io <- module.with_import(
+      import_.new(["gleam", "io"]) |> import_.with_alias("only_o"),
+    )
     use int_mod <- module.with_import(import_.new(["gleam", "int"]))
     use string_mod <- module.with_import(import_.new(["gleam", "string"]))
 

--- a/test/gleamgen_test.gleam
+++ b/test/gleamgen_test.gleam
@@ -1560,6 +1560,109 @@ pub fn main() -> Nil {
   assert result == expected
 }
 
+/// Regression test for `import_.new_with_exposing`: rendered `import path.{items}` and kept in output
+/// when nothing references the module prefix (only unqualified imports from the exposing list).
+pub fn module_import_with_exposing_test() {
+  let mod = {
+    use _string <- module.with_import(import_.new_with_exposing(
+      ["gleam", "string"],
+      "length",
+    ))
+
+    use _main <- module.with_function(
+      definition.new(name: "main")
+        |> definition.with_publicity(True),
+      function.new0(returns: types.nil, handler: fn() { expression.nil() }),
+    )
+    module.eof()
+  }
+
+  let result =
+    mod
+    |> module.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "import gleam/string.{length}
+
+pub fn main() -> Nil {
+  Nil
+}"
+
+  assert result == expected
+}
+
+/// `import path.{items} as alias` — exposing must come before `as` in Gleam syntax.
+pub fn module_import_with_alias_and_exposing_test() {
+  let mod = {
+    use io <- module.with_import(import_.new_with_alias_and_exposing(
+      ["gleam", "io"],
+      "only_o",
+      "println",
+    ))
+
+    let io_print = import_.function1(io, io.println)
+
+    use _main <- module.with_function(
+      definition.new(name: "main")
+        |> definition.with_publicity(True),
+      function.new0(returns: types.nil, handler: fn() {
+        expression.call1(io_print, expression.string("hi"))
+      }),
+    )
+    module.eof()
+  }
+
+  let result =
+    mod
+    |> module.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "import gleam/io.{println} as only_o
+
+pub fn main() -> Nil {
+  only_o.println(\"hi\")
+}"
+
+  assert result == expected
+}
+
+/// Duplicate module paths with separate exposing lists merge into one import (stable order).
+pub fn module_merge_imports_exposing_test() {
+  let mod = {
+    use _ <- module.with_import(import_.new_with_exposing(
+      ["gleam", "string"],
+      "reverse",
+    ))
+    use _ <- module.with_import(import_.new_with_exposing(
+      ["gleam", "string"],
+      "length",
+    ))
+
+    use _main <- module.with_function(
+      definition.new(name: "main")
+        |> definition.with_publicity(True),
+      function.new0(returns: types.nil, handler: fn() { expression.nil() }),
+    )
+    module.eof()
+  }
+
+  let result =
+    mod
+    |> module.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "import gleam/string.{reverse, length}
+
+pub fn main() -> Nil {
+  Nil
+}"
+
+  assert result == expected
+}
+
 pub fn module_unused_import_test() {
   let mod = {
     use io <- module.with_import(import_.new_with_alias(

--- a/test/gleamgen_test.gleam
+++ b/test/gleamgen_test.gleam
@@ -1315,10 +1315,42 @@ pub fn do_result() -> Result(Int, String) {
   assert result == expected
 }
 
+/// Regression test for single-expression blocks in `let` values (`render_block`).
+///
+/// A block value that is only one expression omits redundant `{ ... }`
+/// (e.g. `let y = x + 1`, not `let y = { x + 1 }`).
+pub fn single_expression_block_in_let_value_test() {
+  let value =
+    block.new_dynamic([
+      statement.expression(expression.math_operator(
+        expression.raw("x"),
+        expression.Add,
+        expression.int(1),
+      )),
+    ])
+
+  let result =
+    block.new_dynamic([
+      statement.dynamic_let("y", value, False),
+      statement.expression(expression.raw("y")),
+    ])
+    |> expression.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "{
+  let y = x + 1
+  y
+}"
+
+  assert result == expected
+}
+
 /// Regression test for rendering block arguments in call expressions.
 ///
 /// Ensures calls like `result.try(...)` keep braces for block arguments with
-/// `let` statements, while still unwrapping single direct-return blocks.
+/// `let` statements, while still unwrapping single-expression blocks (via
+/// `render_block`).
 pub fn call_with_block_argument_test() {
   let with_let =
     expression.call_dynamic(expression.raw("result.try"), [

--- a/test/import_dedupe_render_test.gleam
+++ b/test/import_dedupe_render_test.gleam
@@ -3,48 +3,48 @@ import gleam/string
 
 import gleam/option.{Some}
 
-import gleamgen/expression as gex
-import gleamgen/function as gfun
-import gleamgen/import_ as gim
-import gleamgen/module as gmod
-import gleamgen/module/definition as gdef
-import gleamgen/parameter as gparam
-import gleamgen/render as grender
-import gleamgen/types as gtypes
+import gleamgen/expression
+import gleamgen/function
+import gleamgen/import_
+import gleamgen/module
+import gleamgen/module/definition
+import gleamgen/parameter
+import gleamgen/render
+import gleamgen/types
 
 pub fn sort_like_module_emits_one_structure_import_test() {
-  let sm = gim.new(["cat_db", "structure"])
-  let field_t = gtypes.custom_type(Some("structure"), "CatField", [])
+  let sm = import_.new(["cat_db", "structure"])
+  let field_t = types.custom_type(Some("structure"), "CatField", [])
   let func =
-    gfun.new1(gparam.new("field", field_t), gtypes.string, fn(_f) {
-      gex.string("x")
+    function.new1(parameter.new("field", field_t), types.string, fn(_f) {
+      expression.string("x")
     })
   let details =
-    gdef.new("cat_field_sql")
-    |> gdef.with_publicity(True)
+    definition.new("cat_field_sql")
+    |> definition.with_publicity(True)
   let mod =
-    gmod.with_import(sm, fn(_) {
-      gmod.with_function(details, func, fn(_) { gmod.eof() })
+    module.with_import(sm, fn(_) {
+      module.with_function(details, func, fn(_) { module.eof() })
     })
   let s =
-    gmod.render(mod, grender.default_context())
-    |> grender.to_string()
+    module.render(mod, render.default_context())
+    |> render.to_string()
   let parts = string.split(s, "import cat_db/structure")
-  let assert True = list.length(parts) == 2
+  assert list.length(parts) == 2
 }
 
 pub fn function_only_module_does_not_emit_import_lines_test() {
-  let field_t = gtypes.custom_type(Some("structure"), "CatField", [])
+  let field_t = types.custom_type(Some("structure"), "CatField", [])
   let func =
-    gfun.new1(gparam.new("field", field_t), gtypes.string, fn(_f) {
-      gex.string("x")
+    function.new1(parameter.new("field", field_t), types.string, fn(_f) {
+      expression.string("x")
     })
   let details =
-    gdef.new("cat_field_sql")
-    |> gdef.with_publicity(True)
-  let mod = gmod.with_function(details, func, fn(_) { gmod.eof() })
+    definition.new("cat_field_sql")
+    |> definition.with_publicity(True)
+  let mod = module.with_function(details, func, fn(_) { module.eof() })
   let s =
-    gmod.render(mod, grender.default_context())
-    |> grender.to_string()
-  let assert False = string.contains(s, "import ")
+    module.render(mod, render.default_context())
+    |> render.to_string()
+  assert string.contains(s, "import ") == False
 }

--- a/test/import_dedupe_render_test.gleam
+++ b/test/import_dedupe_render_test.gleam
@@ -16,11 +16,9 @@ pub fn sort_like_module_emits_one_structure_import_test() {
   let sm = gim.new(["cat_db", "structure"])
   let field_t = gtypes.custom_type(Some("structure"), "CatField", [])
   let func =
-    gfun.new1(
-      gparam.new("field", field_t),
-      gtypes.string,
-      fn(_f) { gex.string("x") },
-    )
+    gfun.new1(gparam.new("field", field_t), gtypes.string, fn(_f) {
+      gex.string("x")
+    })
   let details =
     gdef.new("cat_field_sql")
     |> gdef.with_publicity(True)
@@ -38,16 +36,13 @@ pub fn sort_like_module_emits_one_structure_import_test() {
 pub fn function_only_module_does_not_emit_import_lines_test() {
   let field_t = gtypes.custom_type(Some("structure"), "CatField", [])
   let func =
-    gfun.new1(
-      gparam.new("field", field_t),
-      gtypes.string,
-      fn(_f) { gex.string("x") },
-    )
+    gfun.new1(gparam.new("field", field_t), gtypes.string, fn(_f) {
+      gex.string("x")
+    })
   let details =
     gdef.new("cat_field_sql")
     |> gdef.with_publicity(True)
-  let mod =
-    gmod.with_function(details, func, fn(_) { gmod.eof() })
+  let mod = gmod.with_function(details, func, fn(_) { gmod.eof() })
   let s =
     gmod.render(mod, grender.default_context())
     |> grender.to_string()

--- a/test/import_dedupe_render_test.gleam
+++ b/test/import_dedupe_render_test.gleam
@@ -1,0 +1,55 @@
+import gleam/list
+import gleam/string
+
+import gleam/option.{Some}
+
+import gleamgen/expression as gex
+import gleamgen/function as gfun
+import gleamgen/import_ as gim
+import gleamgen/module as gmod
+import gleamgen/module/definition as gdef
+import gleamgen/parameter as gparam
+import gleamgen/render as grender
+import gleamgen/types as gtypes
+
+pub fn sort_like_module_emits_one_structure_import_test() {
+  let sm = gim.new(["cat_db", "structure"])
+  let field_t = gtypes.custom_type(Some("structure"), "CatField", [])
+  let func =
+    gfun.new1(
+      gparam.new("field", field_t),
+      gtypes.string,
+      fn(_f) { gex.string("x") },
+    )
+  let details =
+    gdef.new("cat_field_sql")
+    |> gdef.with_publicity(True)
+  let mod =
+    gmod.with_import(sm, fn(_) {
+      gmod.with_function(details, func, fn(_) { gmod.eof() })
+    })
+  let s =
+    gmod.render(mod, grender.default_context())
+    |> grender.to_string()
+  let parts = string.split(s, "import cat_db/structure")
+  let assert True = list.length(parts) == 2
+}
+
+pub fn function_only_module_does_not_emit_import_lines_test() {
+  let field_t = gtypes.custom_type(Some("structure"), "CatField", [])
+  let func =
+    gfun.new1(
+      gparam.new("field", field_t),
+      gtypes.string,
+      fn(_f) { gex.string("x") },
+    )
+  let details =
+    gdef.new("cat_field_sql")
+    |> gdef.with_publicity(True)
+  let mod =
+    gmod.with_function(details, func, fn(_) { gmod.eof() })
+  let s =
+    gmod.render(mod, grender.default_context())
+    |> grender.to_string()
+  let assert False = string.contains(s, "import ")
+}


### PR DESCRIPTION
Hey I decided to batch these changes together because I've needed them all. I know this is a bit harder to review.

Thank you for your feedback on the last PR.


Why this PR

  These changes come from using gleamgen for real codegen (e.g. a DB access layer): generated Gleam should match normal syntax, imports should be controllable and deduplicated, and patterns should be easy to build for case without ad‑hoc strings. The branch fixes several renderer bugs and extends the API so generated modules look like hand-written Gleam and compose safely

  **Summary of changes**



  Block and call rendering (`expression`)

  • Call arguments: Multi-statement block arguments stay wrapped in { ... }; a block that is only a single expression is not wrapped in extra braces (e.g. result.try(Ok(3), Ok(4)) instead of result.try(Ok(3), { Ok(4) })).
  • `render_block`: The same “single expression → no redundant braces” rule applies everywhere blocks are rendered (e.g. let y = x + 1 instead of let y = { x + 1 }), not only inside calls.
  • `render_call`: Arguments are still rendered with bracket semantics so multi-statement block arguments stay correct when the call appears in contexts where the outer level omits braces (e.g. as a function body).

  Why: Matches idiomatic Gleam and avoids misleading or invalid-looking output when blocks are used as values or call arguments.



  Imports (`import_`, `module`)

  • Exposing lists: Support for rendered import path.{…} and correct placement relative to as alias when both are used.
  • Merging: When duplicate module paths are merged, exposing clauses are combined instead of dropped.
  • Predefined imports: Constructors like new_predefined / new_predefined_with_exposing / new_predefined_with_alias so an import is always emitted even when static analysis wouldn’t see a reference (e.g. types embedded only inside nested
    ASTs).
  • Deduping: After merge_imports, duplicate paths are dropped in module output so you don’t get repeated import lines for the same module.

  Why: Real modules need selective imports; generated code often references types through nested structures; merging and deduping keeps output clean and valid.



  Parameters (`parameter`)

  • `render_parameters` merges type reference / import details from every parameter so inferred imports stay complete when types on parameters pull in extra modules.

  Why: Without this, parameter types could require imports that never showed up in the rendered module.



  Patterns (`pattern`)

  • Helpers for foreign and Option patterns so common case branches don’t need manual constructor tuples.
  • Zero-argument constructors render without () (e.g. None, not None()).
  • List helpers for `[]` and `[..name]`, plus `list_first_discard_rest` for a head + rest list binding.

  Why: Correct pattern syntax and less boilerplate when generating case expressions.



  Tests

  • Regression tests for: block/call rendering, let values with single-expression blocks, import exposing/alias/merge/dedupe/predefined behavior, list/option/constructor patterns, and parameter import merging (gleamgen_test +
    import_dedupe_render_test).



  Housekeeping

  • gleam format on touched sources.



  Commits (newest first)

  1. **as per your request** unwrap single-expression blocks in render_block — generalize brace elision; call-arg bracket semantics preserved. 
  2. Run gleam format
  3. add predefined imports, dedupe paths, and parameter pattern helpers
  4. support import exposing lists in module rendering
  5. fix zero-argument constructor pattern rendering (+ list pattern tests)
  6. add helpers for foreign and option patterns
  7. fix block argument rendering in call expressions
