### PR TITLE
Add type annotations to fix "unknown type" compilation errors

### DIFF
--- a/src/gleamgen/expression.gleam
+++ b/src/gleamgen/expression.gleam
@@ -1318,7 +1318,12 @@ fn render_use(func, args, callback_args, context) {
 }
 
 // TODO: clean up
-fn render_case(to_match_on, patterns, all_can_match_on_multiple, context) {
+fn render_case(
+  to_match_on: Expression(type_.Dynamic),
+  patterns: fn(public_render.Context) -> List(fn(Int) -> public_render.Rendered),
+  all_can_match_on_multiple: Bool,
+  context: public_render.Context,
+) -> public_render.Rendered {
   let #(rendered_match_on, subject_count) = case to_match_on.internal {
     TupleLiteral(expressions) if all_can_match_on_multiple -> {
       let #(expressions, details) = render_expressions(expressions, context)


### PR DESCRIPTION
When running `gleam build` on this package using Gleam v1.16.0, I get the output below, with error “Unknown type for record access”. I fixed the errors by adding an explicit type signature to the offending function. Let me know if you'd rather import the types instead of using them with their qualified name, I'll do the fix.

```
﻿  Compiling gleamgen
warning: Unused function argument
     ┌─ /Users/Ale/mydata/personal/interactive/library/_external/gleamgen/src/gleamgen/expression.gleam:1338:29
     │
1338 │       list.map(patterns, fn(m) { m.details }),
     │                             ^ This argument is never used

Hint: You can ignore it with an underscore: `_m`.

warning: Unused function argument
     ┌─ /Users/Ale/mydata/personal/interactive/library/_external/gleamgen/src/gleamgen/expression.gleam:1349:24
     │
1349 │         |> list.map(fn(m) { m.doc })
     │                        ^ This argument is never used

Hint: You can ignore it with an underscore: `_m`.

error: Unknown type for record access
     ┌─ /Users/Ale/mydata/personal/interactive/library/_external/gleamgen/src/gleamgen/expression.gleam:1322:50
     │
1322 │   let #(rendered_match_on, subject_count) = case to_match_on.internal {
     │                                                  ^^^^^^^^^^^ I don't know what type this is

In order to access a record field we need to know what type it is, but I
can't tell the type here. Try adding type annotations to your function and
try again.

error: Unknown type for record access
     ┌─ /Users/Ale/mydata/personal/interactive/library/_external/gleamgen/src/gleamgen/expression.gleam:1338:34
     │
1338 │       list.map(patterns, fn(m) { m.details }),
     │                                  ^ I don't know what type this is

In order to access a record field we need to know what type it is, but I
can't tell the type here. Try adding type annotations to your function and
try again.

error: Unknown type for record access
     ┌─ /Users/Ale/mydata/personal/interactive/library/_external/gleamgen/src/gleamgen/expression.gleam:1349:29
     │
1349 │         |> list.map(fn(m) { m.doc })
     │                             ^ I don't know what type this is

In order to access a record field we need to know what type it is, but I
can't tell the type here. Try adding type annotations to your function and
try again.
```

Thank you for the useful library! 🧡