### PR TITLE
Add white space after module documentation

### DIFF
--- a/src/gleamgen/module.gleam
+++ b/src/gleamgen/module.gleam
@@ -1105,23 +1105,18 @@ pub fn render(
       }),
       doc.line,
     )
-    |> doc.append(case module.module_documentation_comments, rendered_imports {
-      [], _ | _, [] -> doc.empty
-      _, _ -> doc.line
+    |> doc.append(case module.module_documentation_comments {
+      [] -> doc.empty
+      _ -> doc.concat([doc.line, doc.line])
     })
 
   rendered_imports
   |> doc.join(with: doc.line)
   |> doc.prepend(documentation_comments)
-  |> doc.append(
-    case
-      list.is_empty(rendered_imports)
-      && list.is_empty(module.module_documentation_comments)
-    {
-      True -> doc.empty
-      False -> doc.concat([doc.line, doc.line])
-    },
-  )
+  |> doc.append(case rendered_imports {
+    [] -> doc.empty
+    _ -> doc.concat([doc.line, doc.line])
+  })
   |> doc.append(doc.concat_join(rendered_defs, [doc.line, doc.line]))
   |> render.Render(details:)
 }

--- a/test/module_test.gleam
+++ b/test/module_test.gleam
@@ -68,6 +68,47 @@ pub const favorite_number = 46"
   assert result == expected
 }
 
+pub fn module_documentation_comments_and_imports_test() {
+  let mod = {
+    use <- module.with_module_documentation_comments([
+      "This is a module",
+      "It has documentation comments",
+    ])
+
+    use io_mod <- module.with_import(import_.new(["gleam", "io"]))
+
+    let io_println =
+      import_.value_of_type(io_mod, "println", type_.reference(io.println))
+
+    use _ <- module.with_function(
+      definition.new("main") |> definition.with_publicity(True),
+      function.new0(type_.nil, fn() {
+        expression.call1(io_println, expression.string("Hello, world!"))
+      }),
+    )
+
+    module.eof()
+  }
+
+  let result =
+    mod
+    |> module.render(render.default_context())
+    |> render.to_string()
+
+  let expected =
+    "//// This is a module
+//// It has documentation comments
+
+import gleam/io
+
+pub fn main() -> Nil {
+  io.println(\"Hello, world!\")
+}"
+
+  assert result == expected
+}
+
+
 const sample_module = "import gleam/int
 import gleam/io
 


### PR DESCRIPTION
The standard gleam formatter emits code like:

```
//// This is module comment

import gleam/io
```

The formatter currently emits this as one block:

```
//// This is module comment
import gleam/io
```

This commit changes this to adhere to the gleam formatter,