### PR TITLE
Add additional empty line at the and of the module to comply with gleam format

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+gleam = "latest"


### PR DESCRIPTION
Gleam format adds an eol after the last line (which is compliant with most editors). Since after each function also an eol is expected, I didn't update the final rendering after: https://github.com/BrewingWeasel/gleamgen/blob/99cf773bd5ac61bbc6057564ce94246cffdc0ff8/src/gleamgen/module.gleam#L1120 but opted to add the new line to the rendering of the module details and don't join the details with an empty line in between anymore. This reduces the chance of 2 consecutive empty lines because there are no details to render.