### PR TITLE
Import generic module

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gleamgen"
-version = "1.0.3"
+version = "1.0.4"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.

--- a/src/gleamgen/type_.gleam
+++ b/src/gleamgen/type_.gleam
@@ -509,7 +509,7 @@ fn render_custom(
       let module_to_use = render.get_import_from_context(context, module)
       let doc = import_reference.get_reference(module_to_use, name)
 
-      let details = render.add_import_to_details(render.empty_details, module)
+      let details = render.add_import_to_details(details, module)
       #(details, doc)
     }
     option.None -> #(details, doc.from_string(name))

--- a/test/type_test.gleam
+++ b/test/type_test.gleam
@@ -1,0 +1,45 @@
+import gleam/option
+import gleamgen/expression
+import gleamgen/function
+import gleamgen/import_
+import gleamgen/internal/render
+import gleamgen/module
+import gleamgen/module/definition
+import gleamgen/type_
+
+pub fn module_with_generic_type_emits_imports_for_type_args_test() {
+  let mod = {
+    use mist_module <- module.with_import(import_.new(["mist"]))
+    use response_module <- module.with_import(
+      import_.new(["gleam", "http", "response"]),
+    )
+
+    let mist_data =
+      type_.custom_type(option.Some(mist_module), "ResponseData", [])
+    let return_type =
+      type_.custom_type(option.Some(response_module), "Response", [
+        mist_data |> type_.to_dynamic(),
+      ])
+
+    use _handler <- module.with_function(
+      definition.new("handler") |> definition.with_publicity(True),
+      function.new0(returns: return_type, handler: fn() {
+        expression.todo_(option.None)
+      }),
+    )
+    module.eof()
+  }
+
+  let result =
+    mod |> module.render(render.default_context()) |> render.to_string()
+
+  let expected =
+    "import gleam/http/response
+import mist
+
+pub fn handler() -> response.Response(mist.ResponseData) {
+  todo
+}"
+
+  assert result == expected
+}


### PR DESCRIPTION
If a generic part of a module was generated e.g.:

```pub fn test(conn: http.Request(mist.Connection))```

only the http module was included as an import. After this change both http and mist are included as import.